### PR TITLE
docs: update the link to astro.endfield.icu

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -1,4 +1,4 @@
-# Welcome back [AstroEndfield](https://astro.endfield.tech/)
+# Welcome back [AstroEndfield](https://astro.endfield.icu/)
 
 [简体中文](./README.md)
 | [日本語（TODO）](./README.ja.md)

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,4 +1,4 @@
-# おかりなさい　[AstroEndfield](https://astro.endfield.tech/)
+# おかりなさい　[AstroEndfield](https://astro.endfield.icu/)
 
 [简体中文](./README.md)
 | [日本語（TODO）](./README.ja.md)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 欢迎回归 [AstroEndfield](https://astro.endfield.tech/)
+# 欢迎回归 [AstroEndfield](https://astro.endfield.icu/)
 
 ![](./public/assets/img/astro-endfield-logo.svg)
 

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -5,7 +5,7 @@ import tailwind from "@astrojs/tailwind";
 // https://astro.build/config
 // https://docs.astro.build/zh-cn/reference/configuration-reference/
 export default defineConfig({
-  site: "https://astro.endfield.tech/",
+  site: "https://astro.endfield.icu/",
   markdown: {
     shikiConfig: {
       theme: "slack-dark"


### PR DESCRIPTION
将文档和代码中的 `astro.endfield.tech` 改为 `astro.endfield.icu`，与 https://github.com/Yue-plus/astro-endfield/commit/5a9441128daf9dc24bd2066d09383fd4f2f47b77 这个 commit 保持一致。建议重新部署，避免示例网站访问失效。

此外，[deploy.yml](https://github.com/Yue-plus/astro-endfield/blob/main/.github/workflows/deploy.yml) 所使用的 actions 已弃用，需要对应更新，可参考最新的文档 https://github.com/withastro/action 。

> PS: 我在维护 [Awesome Arknights](https://github.com/palmcivet/awesome-arknights) 项目时发现链接失效，遂修改并发起 PR。非常感谢作者开源了众多明日方舟衍生项目。